### PR TITLE
refactored transactions, read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ An example of an application combining Clean Architecture and DDD.
 
 Here is [the article](https://medium.com/@gushakov/2236f5430a05) which describes the ideas for this application.
 
+### How to run
+
+- start the Postgres database using provided `docker-compose.yml`
+- Swagger UI can be accessed at the URL: http://localhost:8080/swagger-ui/index.html
+
 ### References
 
 Here are some references and links which were used for this application:

--- a/src/main/java/com/github/cleanddd/core/GenericEnrollmentError.java
+++ b/src/main/java/com/github/cleanddd/core/GenericEnrollmentError.java
@@ -5,4 +5,7 @@ public class GenericEnrollmentError extends RuntimeException {
         super(message);
     }
 
+    public GenericEnrollmentError(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/github/cleanddd/core/port/db/EntityDoesNotExistError.java
+++ b/src/main/java/com/github/cleanddd/core/port/db/EntityDoesNotExistError.java
@@ -1,8 +1,6 @@
 package com.github.cleanddd.core.port.db;
 
-import com.github.cleanddd.core.GenericEnrollmentError;
-
-public class EntityDoesNotExistError extends GenericEnrollmentError {
+public class EntityDoesNotExistError extends PersistenceError {
     public EntityDoesNotExistError(String message) {
         super(message);
     }

--- a/src/main/java/com/github/cleanddd/core/port/db/PersistenceError.java
+++ b/src/main/java/com/github/cleanddd/core/port/db/PersistenceError.java
@@ -1,0 +1,13 @@
+package com.github.cleanddd.core.port.db;
+
+import com.github.cleanddd.core.GenericEnrollmentError;
+
+public class PersistenceError extends GenericEnrollmentError {
+    public PersistenceError(String message) {
+        super(message);
+    }
+
+    public PersistenceError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/github/cleanddd/core/port/db/PersistenceOperationsOutputPort.java
+++ b/src/main/java/com/github/cleanddd/core/port/db/PersistenceOperationsOutputPort.java
@@ -7,9 +7,20 @@ import com.github.cleanddd.core.model.student.Student;
 import java.util.Set;
 
 public interface PersistenceOperationsOutputPort {
-    Integer persist(Course course);
 
-    void rollback();
+    /**
+     * Executes provided {@linkplain Runnable} in a transaction configured
+     * with default propagation strategy and isolation level.
+     *
+     * @param runnable runnable to execute
+     * @throws PersistenceError if there was a problem setting up or executing
+     *                          a transaction, all other {@linkplain RuntimeException}s
+     *                          which may be thrown by the {@code runnable} itself are
+     *                          propagated to the caller
+     */
+    void doInTransaction(Runnable runnable);
+
+    Integer persist(Course course);
 
     Course obtainCourseById(Integer courseId);
 

--- a/src/main/java/com/github/cleanddd/infrastructure/adapter/db/PersistenceGateway.java
+++ b/src/main/java/com/github/cleanddd/infrastructure/adapter/db/PersistenceGateway.java
@@ -4,22 +4,32 @@ import com.github.cleanddd.core.model.course.Course;
 import com.github.cleanddd.core.model.enrollment.Enrollment;
 import com.github.cleanddd.core.model.student.Student;
 import com.github.cleanddd.core.port.db.EntityDoesNotExistError;
+import com.github.cleanddd.core.port.db.PersistenceError;
 import com.github.cleanddd.core.port.db.PersistenceOperationsOutputPort;
 import com.github.cleanddd.infrastructure.adapter.db.course.CourseEntityRepository;
 import com.github.cleanddd.infrastructure.adapter.db.enrollment.EnrollmentRow;
 import com.github.cleanddd.infrastructure.adapter.db.map.DbMapper;
 import com.github.cleanddd.infrastructure.adapter.db.student.StudentEntityRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.NoTransactionException;
-import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+/*
+    References:
+    ----------
+
+    1.  Spring, TransactionTemplate: source code and JavaDoc
+ */
 
 @Service
 @RequiredArgsConstructor
@@ -29,23 +39,28 @@ public class PersistenceGateway implements PersistenceOperationsOutputPort {
     final StudentEntityRepository studentRepo;
     final NamedParameterJdbcOperations jdbcOps;
     final DbMapper dbMapper;
+    final TransactionTemplate transactionTemplate;
 
     @Override
-    public Integer persist(Course course) {
-        return courseRepo.save(dbMapper.map(course)).getId();
-    }
-
-    @Override
-    public void rollback() {
-        // roll back any transaction, if needed
-        // code from: https://stackoverflow.com/a/23502214
+    public void doInTransaction(Runnable runnable) {
         try {
-            TransactionInterceptor.currentTransactionStatus().setRollbackOnly();
-        } catch (NoTransactionException e) {
-            // do nothing if not running in a transactional context
+            transactionTemplate.executeWithoutResult(status -> runnable.run());
+        } catch (TransactionException | Error e) {
+            throw new PersistenceError("Error while executing transaction", e);
         }
     }
 
+    @Transactional
+    @Override
+    public Integer persist(Course course) {
+        try {
+            return courseRepo.save(dbMapper.map(course)).getId();
+        } catch (Exception e) {
+            throw new PersistenceError("Error saving course with ID: %d".formatted(course.getId()), e);
+        }
+    }
+
+    @Transactional(readOnly = true)
     @Override
     public Course obtainCourseById(Integer courseId) {
         try {
@@ -55,16 +70,28 @@ public class PersistenceGateway implements PersistenceOperationsOutputPort {
         }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public boolean courseExistsWithTitle(String title) {
-        return courseRepo.existsCourseEntityByTitleLike(title);
+        try {
+            return courseRepo.existsCourseEntityByTitleLike(title);
+        } catch (Exception e) {
+            throw new PersistenceError("Could not query for course with title matching: \"%s\""
+                    .formatted(title), e);
+        }
     }
 
+    @Transactional
     @Override
     public Integer persist(Student student) {
-        return studentRepo.save(dbMapper.map(student)).getId();
+        try {
+            return studentRepo.save(dbMapper.map(student)).getId();
+        } catch (Exception e) {
+            throw new PersistenceError("Error saving student with ID: %d".formatted(student.getId()), e);
+        }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Student obtainStudentById(Integer studentId) {
         try {
@@ -74,18 +101,28 @@ public class PersistenceGateway implements PersistenceOperationsOutputPort {
         }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public boolean studentExistsWithFullName(String fullName) {
-        return studentRepo.existsByFullNameLike(fullName);
+        try {
+            return studentRepo.existsByFullNameLike(fullName);
+        } catch (Exception e) {
+            throw new PersistenceError("Could not query for student with full name: %s".formatted(fullName));
+        }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Set<Enrollment> findEnrollments(Integer studentId) {
 
-        return jdbcOps.queryForStream(EnrollmentRow.SQL,
-                        Map.of("studentId", studentId),
-                        new BeanPropertyRowMapper<>(EnrollmentRow.class))
-                .map(dbMapper::map)
-                .collect(Collectors.toSet());
+        try {
+            return jdbcOps.queryForStream(EnrollmentRow.SQL,
+                            Map.of("studentId", studentId),
+                            new BeanPropertyRowMapper<>(EnrollmentRow.class))
+                    .map(dbMapper::map)
+                    .collect(Collectors.toSet());
+        } catch (DataAccessException e) {
+            throw new PersistenceError("Could not query for enrollments with for student with ID: %d".formatted(studentId));
+        }
     }
 }

--- a/src/main/java/com/github/cleanddd/infrastructure/adapter/web/AbstractRestPresenter.java
+++ b/src/main/java/com/github/cleanddd/infrastructure/adapter/web/AbstractRestPresenter.java
@@ -42,7 +42,9 @@ public abstract class AbstractRestPresenter implements ErrorHandlingPresenterOut
         try {
             jacksonConverter.write(content, MediaType.APPLICATION_JSON, httpOutputMessage);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            // not propagating a technical error back to use case
+            // to avoid an error handling loop
+            log.error(e.getMessage(), e);
         }
 
     }
@@ -62,9 +64,10 @@ public abstract class AbstractRestPresenter implements ErrorHandlingPresenterOut
 
             jacksonConverter.write(Map.of("error", String.valueOf(e.getMessage())),
                     MediaType.APPLICATION_JSON, httpOutputMessage);
-        } catch (Exception error) {
-            // should not propagate any errors to the use case
-            log.error(error.getMessage(), e);
+        } catch (IOException ex) {
+            // not propagating a technical error back to use case
+            // to avoid an error handling loop
+            log.error(ex.getMessage(), ex);
         }
 
     }

--- a/src/main/java/com/github/cleanddd/infrastructure/adapter/web/enrollstudent/EnrollStudentPresenter.java
+++ b/src/main/java/com/github/cleanddd/infrastructure/adapter/web/enrollstudent/EnrollStudentPresenter.java
@@ -17,65 +17,41 @@ public class EnrollStudentPresenter extends AbstractRestPresenter implements Enr
 
     @Override
     public void presentMessageWhenCreatingNewCourseIfItExistsAlready() {
-        try {
-            presentOk(CreateCourseResponse
-                    .builder()
-                    .existsAlready(true)
-                    .build());
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(CreateCourseResponse
+                .builder()
+                .existsAlready(true)
+                .build());
     }
 
     @Override
     public void presentResultOfSuccessfulCreationOfNewCourse(Integer courseId) {
-        try {
-            presentOk(CreateCourseResponse.builder()
-                    .existsAlready(false)
-                    .courseId(courseId)
-                    .build());
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(CreateCourseResponse.builder()
+                .existsAlready(false)
+                .courseId(courseId)
+                .build());
     }
 
     @Override
     public void presentMessageWhenCreatingNewStudentIfSheExistsAlready() {
-        try {
-            presentOk(CreateStudentResponse.builder()
-                    .existsAlready(true)
-                    .build());
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(CreateStudentResponse.builder()
+                .existsAlready(true)
+                .build());
     }
 
     @Override
     public void presentResultOfSuccessfulCreationOfNewStudent(Integer studentId) {
-        try {
-            presentOk(CreateStudentResponse.builder().existsAlready(false)
-                    .studentId(studentId)
-                    .build());
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(CreateStudentResponse.builder().existsAlready(false)
+                .studentId(studentId)
+                .build());
     }
 
     @Override
     public void presentResultOfSuccessfulEnrollment(EnrollResult enrollResult) {
-        try {
-            presentOk(enrollResult);
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(enrollResult);
     }
 
     @Override
     public void presentResultOfQueryForStudentEnrollments(Set<Enrollment> enrollments) {
-        try {
-            presentOk(enrollments);
-        } catch (Exception e) {
-            presentError(e);
-        }
+        presentOk(enrollments);
     }
 }


### PR DESCRIPTION
Remove @Transactional on the use cases, handle transactions on the individual methods of the gateway. Provide for a possibility to manually run a block of code in a use case as transactional, if needed (using org.springframework.transaction.support.TransactionTemplate in the persistence gateway).